### PR TITLE
don't return err if err is ERROR_SUCCESS

### DIFF
--- a/uptime/uptime_windows.go
+++ b/uptime/uptime_windows.go
@@ -6,5 +6,11 @@ var getTickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount")
 
 func get() (float64, error) {
 	r, _, err := getTickCount.Call()
+	if errno, ok := err.(syscall.Errno); ok {
+		if errno != 0 {
+			return 0, err
+		}
+		err = nil
+	}
 	return float64(r) / 1000, err
 }

--- a/uptime/uptime_windows.go
+++ b/uptime/uptime_windows.go
@@ -2,7 +2,9 @@ package uptime
 
 import "syscall"
 
-var getTickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount")
+var (
+	getTickCount = syscall.NewLazyDLL("kernel32.dll").NewProc("GetTickCount")
+)
 
 func get() (float64, error) {
 	r, _, err := getTickCount.Call()
@@ -10,7 +12,7 @@ func get() (float64, error) {
 		if errno != 0 {
 			return 0, err
 		}
-		err = nil
+		return float64(r) / 1000, nil
 	}
-	return float64(r) / 1000, err
+	return 0, err
 }


### PR DESCRIPTION
err が ERROR_SUCCESS の時に non-nil になるので syscall.Errno が 0 の時は nil にする様にしました。