### PR TITLE
Add pluginutil

### DIFF
--- a/pluginutil/tempfile.go
+++ b/pluginutil/tempfile.go
@@ -1,0 +1,14 @@
+package pluginutil
+
+import (
+	"os"
+)
+
+// PluginWorkDir returns path for mackerel-agent plugins' cache / tempfiles
+func PluginWorkDir() string {
+	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	return dir
+}

--- a/pluginutil/tempfile_test.go
+++ b/pluginutil/tempfile_test.go
@@ -1,0 +1,26 @@
+package pluginutil
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGenerateTempfilePathWithBase(t *testing.T) {
+	origDir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
+	os.Setenv("MACKEREL_PLUGIN_WORKDIR", "")
+	defer os.Setenv("MACKEREL_PLUGIN_WORKDIR", origDir)
+
+	expect1 := os.TempDir()
+	defaultPath := PluginWorkDir()
+	if defaultPath != expect1 {
+		t.Errorf("PluginWorkDir() should be %s, but: %s", expect1, defaultPath)
+	}
+
+	os.Setenv("MACKEREL_PLUGIN_WORKDIR", "/SOME-SPECIAL-PATH")
+
+	expect2 := "/SOME-SPECIAL-PATH"
+	pathFromEnv := PluginWorkDir()
+	if pathFromEnv != expect2 {
+		t.Errorf("PluginWorkDir() should be %s, but: %s", expect2, pathFromEnv)
+	}
+}


### PR DESCRIPTION
Sometimes agent and (agent|check|meta)-plugins should share implementation around plugins, so I'd like to add a new utility package `pluginutil` and a method `PluginWorkDir()` in it.