### PR TITLE
Add logger.

### DIFF
--- a/logger/level.go
+++ b/logger/level.go
@@ -1,0 +1,34 @@
+package logger
+
+import "fmt"
+
+type level uint8
+
+// loglevels
+const (
+	_ level = iota
+	TRACE
+	DEBUG
+	INFO
+	WARNING
+	ERROR
+	CRITICAL
+)
+
+func (l level) String() string {
+	switch l {
+	case TRACE:
+		return "TRACE"
+	case DEBUG:
+		return "DEBUG"
+	case INFO:
+		return "INFO"
+	case WARNING:
+		return "WARNING"
+	case ERROR:
+		return "ERROR"
+	case CRITICAL:
+		return "CRITICAL"
+	}
+	return fmt.Sprintf("level(%d)", l)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,75 @@
+package logger
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+// Logger struct for logging
+type Logger struct {
+	tag string
+}
+
+// GetLogger get the logger
+func GetLogger(tag string) *Logger {
+	return &Logger{tag: tag}
+}
+
+// global log level
+var logLv = INFO
+var lgr = log.New(os.Stderr, "", log.LstdFlags)
+
+// SetLogLevel congigure log settings
+func SetLogLevel(lv level) {
+	if logLv != lv {
+		logLv = lv
+		if logLv <= DEBUG {
+			lgr.SetFlags(log.LstdFlags | log.Lshortfile)
+		} else {
+			lgr.SetFlags(log.LstdFlags)
+		}
+	}
+}
+
+func (logger *Logger) message(lv level, message string) string {
+	return lv.String() + " <" + logger.tag + "> " + message
+}
+
+func (logger *Logger) log(lv level, message string, args ...interface{}) {
+	if lv >= logLv {
+		// caller -> Infof() -> log()
+		const depth = 3
+		lgr.Output(depth, fmt.Sprintf(logger.message(lv, message), args...))
+	}
+}
+
+// Criticalf critical log
+func (logger *Logger) Criticalf(m string, args ...interface{}) {
+	logger.log(CRITICAL, m, args...)
+}
+
+// Errorf error log
+func (logger *Logger) Errorf(m string, args ...interface{}) {
+	logger.log(ERROR, m, args...)
+}
+
+// Warningf warning log
+func (logger *Logger) Warningf(m string, args ...interface{}) {
+	logger.log(WARNING, m, args...)
+}
+
+// Infof info log
+func (logger *Logger) Infof(m string, args ...interface{}) {
+	logger.log(INFO, m, args...)
+}
+
+// Debugf debug log
+func (logger *Logger) Debugf(m string, args ...interface{}) {
+	logger.log(DEBUG, m, args...)
+}
+
+// Tracef trace log for debugging details
+func (logger *Logger) Tracef(m string, args ...interface{}) {
+	logger.log(TRACE, m, args...)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,58 @@
+package logger
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetLogger(t *testing.T) {
+	var logger = GetLogger("tag")
+	if logger.tag != "tag" {
+		t.Errorf("tag should be tag but %v", logger.tag)
+	}
+}
+
+func TestSetLogLevel(t *testing.T) {
+	SetLogLevel(INFO)
+	if logLv != INFO {
+		t.Errorf("tag should be tag but %v", logLv.String())
+	}
+}
+
+// These tests do not check anything yet.
+// You can see result by go test -v
+func TestLogf(t *testing.T) {
+	SetLogLevel(TRACE)
+
+	var logger = GetLogger("tag")
+	logger.Criticalf("This is critical log: %v", time.Now())
+	logger.Errorf("This is error log: %v", time.Now())
+	logger.Warningf("This is warning log: %v", time.Now())
+	logger.Infof("This is info log: %v", time.Now())
+	logger.Debugf("This is debug log: %v", time.Now())
+	logger.Tracef("This is trace log: %v", time.Now()) // Shown until here
+}
+
+func TestInfoLogf(t *testing.T) {
+	SetLogLevel(INFO)
+
+	var logger = GetLogger("tag")
+	logger.Criticalf("This is critical log: %v", time.Now())
+	logger.Errorf("This is error log: %v", time.Now())
+	logger.Warningf("This is warning log: %v", time.Now())
+	logger.Infof("This is info log: %v", time.Now()) // Shown until here
+	logger.Debugf("This is debug log: %v", time.Now())
+	logger.Tracef("This is trace log: %v", time.Now())
+}
+
+func TestCriticalLogf(t *testing.T) {
+	SetLogLevel(CRITICAL)
+
+	var logger = GetLogger("tag")
+	logger.Criticalf("This is critical log: %v", time.Now()) // Shown until here
+	logger.Errorf("This is error log: %v", time.Now())
+	logger.Warningf("This is warning log: %v", time.Now())
+	logger.Infof("This is info log: %v", time.Now())
+	logger.Debugf("This is debug log: %v", time.Now())
+	logger.Tracef("This is trace log: %v", time.Now())
+}


### PR DESCRIPTION
This implementation is taken from mackerel-agent ([github.com/mackerelio/mackerel-agent/logging](https://github.com/mackerelio/mackerel-agent/blob/master/logging/logging.go)).
It's not good for plugins to depend on mackerel-agent, so I'd like to suggest plugins (and agent itself) to use this logger.