### PR TITLE
add a simple test for uptime.Get()

### DIFF
--- a/uptime/uptime_test.go
+++ b/uptime/uptime_test.go
@@ -9,5 +9,8 @@ func TestGet(t *testing.T) {
 	if err != nil {
 		t.Errorf("error should be nil but: %s", err)
 	}
+	if v <= 0.0 {
+		t.Errorf("uptime should be positive but got: %f", v)
+	}
 	t.Logf("uptime: %f", v)
 }

--- a/uptime/uptime_test.go
+++ b/uptime/uptime_test.go
@@ -1,0 +1,13 @@
+package uptime
+
+import (
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	v, err := Get()
+	if err != nil {
+		t.Errorf("error should be nil but: %s", err)
+	}
+	t.Logf("uptime: %f", v)
+}


### PR DESCRIPTION
I think there should be a test for uptime.Get, which runs on multiple OS.