### PR TITLE
[nit] Use Go 1.9.x on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-- 1.9
+- 1.9.x
 script:
 - make lint
 - make cover


### PR DESCRIPTION
Upgrade the Go version to the latest.