### PR TITLE
upgrade Go toolchain: 1.9 -> 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-- 1.9.x
+- 1.11.x
 script:
 - make lint
 - make cover


### PR DESCRIPTION
fix CVE-2019-6486

golang/go#29903