### PR TITLE
[nit] upgrade actions/setup-go and actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: actions/setup-go@v2-beta
+    - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
     - run: make lint cover


### PR DESCRIPTION
actions/setup-go@v2-beta will be stopped with many errors:

> The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.

Therefore we should upgrade it to v2.