### PR TITLE
upgrade Go, ubuntu-runner, etc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
     - master
   pull_request:
-env:
-  GO111MODULE: on
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -14,12 +12,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.35
+        version: v1.42
   test:
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'macOS-10.15', 'windows-2019']
-        go: ['1.16.x', '1.15.x', '1.14.x']
+        os: ['ubuntu-20.04', 'macOS-10.15', 'windows-2019']
+        go: ['1.17.x', '1.16.x']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mackerelio/golib
 
-go 1.15
+go 1.16


### PR DESCRIPTION
* Go: supports latest two versions (1.17, 1.16)
* Ubuntu: 18.04 -> 20.04
* golangci-lint: 1.35 -> 1.42