### PR TITLE
pinned workflows/go-test@v1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,6 @@ on:
   pull_request:
 jobs:
   lint:
-    uses: mackerelio/workflows/.github/workflows/go-lint.yml@main
+    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.0.1
   test:
-    uses: mackerelio/workflows/.github/workflows/go-test.yml@main
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.0.1


### PR DESCRIPTION
I pinned workflows version.
Its version is based on Go 1.20 and 1.21 by default.