### PR TITLE
remove coveralls status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 github.com/mackerelio/golib
 ===
 [![Build Status](https://github.com/mackerelio/golib/workflows/Build/badge.svg?branch=master)][actions]
-[![Coverage Status](https://coveralls.io/repos/mackerelio/golib/badge.svg?branch=master)][coveralls]
 [![pkg.go.dev](https://pkg.go.dev/badge/github.com/mackerelio/golib)][pkg.go.dev]
 
 [actions]: https://github.com/mackerelio/golib/actions?workflow=Build
-[coveralls]: https://coveralls.io/r/mackerelio/golib?branch=master
 [pkg.go.dev]: https://pkg.go.dev/github.com/mackerelio/golib
 
 github.com/mackerelio/golib - go libraries for [Mackerel][Mackerel] products


### PR DESCRIPTION
We stopped to send code coverage to Coveralls since I was merged #43  so we should remove its badge.